### PR TITLE
Phantoms: reworked to be functional on GPUs other than Apple Intel Iris

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/kernels/phantoms.cl
+++ b/src/main/java/net/haesleinhuepf/clij/kernels/phantoms.cl
@@ -5,7 +5,21 @@
 //default xorfractal u =0f
 
 
-__kernel void xorfractal  (DTYPE_IMAGE_OUT_3D dst, 
+__kernel void xorfractal_2d(DTYPE_IMAGE_OUT_2D dst, 
+                                        int       dx, 
+                                        int       dy, 
+                                        float     u 
+                          )
+{
+	int x = get_global_id(0); 
+	int y = get_global_id(1);
+        float value = u*((x+dx)^((y+dy)+1)^(2));
+	
+	WRITE_IMAGE_2D (dst, (int2){x, y}, CONVERT_DTYPE_OUT(value));
+}
+
+
+__kernel void xorfractal_3d(DTYPE_IMAGE_OUT_3D dst, 
                                         int       dx, 
                                         int       dy, 
                                         float     u 
@@ -14,9 +28,41 @@ __kernel void xorfractal  (DTYPE_IMAGE_OUT_3D dst,
 	int x = get_global_id(0); 
 	int y = get_global_id(1);
 	int z = get_global_id(2);
+        float value = u*((x+dx)^((y+dy)+1)^(z+2));
 	
-	WRITE_IMAGE_3D (dst, (int4)(x, y, z, 0), u*((x+dx)^((y+dy)+1)^(z+2)));
+	WRITE_IMAGE_3D (dst, (int4){x, y, z, 0}, CONVERT_DTYPE_OUT(value));
 }
+
+
+// A kernel to fill an image with a xor fractal filled sphere:
+//default xorsphere cx=0i
+//default xorsphere cy=0i
+//default xorsphere r =80f
+__kernel void xorsphere_2d(DTYPE_IMAGE_OUT_2D dst, 
+                                        int       cx, 
+                                        int       cy,
+                                        float     r 
+                          )
+{
+  const int width  = get_image_width(dst);
+  const int height = get_image_height(dst);
+  
+  float2 dim = (float2){width,height};
+  
+  int x = get_global_id(0); 
+  int y = get_global_id(1);
+  
+  float2 pos = (float2){x,y};
+  
+  float2 cen = (float2){cx,cy};
+  
+  float d = fast_length((pos-cen)/dim);
+  
+  float value = (float)( (x^y)*((d<r)?1:0) );
+  
+  WRITE_IMAGE_2D (dst, (int2){x,y}, CONVERT_DTYPE_OUT(value));
+}
+
 
 
 // A kernel to fill an image with a xor fractal filled sphere:
@@ -24,7 +70,7 @@ __kernel void xorfractal  (DTYPE_IMAGE_OUT_3D dst,
 //default xorsphere cy=0i
 //default xorsphere cz=0i
 //default xorsphere r =80f
-__kernel void xorsphere   (DTYPE_IMAGE_OUT_3D dst, 
+__kernel void xorsphere_3d(DTYPE_IMAGE_OUT_3D dst, 
                                         int       cx, 
                                         int       cy,
                                         int       cz,  
@@ -58,7 +104,39 @@ __kernel void xorsphere   (DTYPE_IMAGE_OUT_3D dst,
 //default sphere cy=0i
 //default sphere cz=0i
 //default sphere r =80f
-__kernel void sphere   (DTYPE_IMAGE_OUT_3D dst, 
+__kernel void sphere_2d(DTYPE_IMAGE_OUT_2D dst, 
+                                        int       cx, 
+                                        int       cy, 
+                                        float     r 
+                          )
+{
+  const int width  = get_image_width(dst);
+  const int height = get_image_height(dst);
+  
+  float2 dim = (float2){width,height};
+  
+  int x = get_global_id(0); 
+  int y = get_global_id(1);
+  
+  float2 pos = (float2){x,y};
+  
+  float2 cen = (float2){cx,cy};
+  
+  float d = fast_length((pos-cen)/dim);
+  
+  float value = (float)((d<r)?1:0);
+  
+  WRITE_IMAGE_2D (dst, (int2){x,y}, CONVERT_DTYPE_OUT(value));
+}
+
+
+
+// A kernel to fill an image with a uniform filled sphere:
+//default sphere cx=0i
+//default sphere cy=0i
+//default sphere cz=0i
+//default sphere r =80f
+__kernel void sphere_3d(DTYPE_IMAGE_OUT_3D dst, 
                                         int       cx, 
                                         int       cy,
                                         int       cz,  
@@ -83,39 +161,5 @@ __kernel void sphere   (DTYPE_IMAGE_OUT_3D dst,
   
   float value = (float)((d<r)?1:0);
   
-  WRITE_IMAGE_3D (dst, (int4){x,y,z,0}, value);
+  WRITE_IMAGE_3D (dst, (int4){x,y,z,0}, CONVERT_DTYPE_OUT(value));
 }
-
-// A kernel to fill an image with a line:
-//default aline a=0i
-//default aline b=0i
-//default aline c=0i
-//default aline d=1i
-//default aline r=0.1f
-__kernel void aline   (DTYPE_IMAGE_OUT_3D dst, 
-                                   int       a, 
-                                   int       b,
-                                   int       c,
-                                   int       d,  
-                                   float     r 
-                     )
-{
-  const int width  = get_image_width(dst);
-  const int height = get_image_height(dst);
-  const int depth  = get_image_depth(dst);
-  
-  const int x = get_global_id(0); 
-  const int y = get_global_id(1);
-  const int z = get_global_id(2);
-  
-  float4 pos = (float4){x,y,z,0};
-  
-  float4 vec = (float4){a,b,c,d};
-  
-  float dist = fabs(dot(pos,vec));
-  
-  float value = (float)((dist<r)?1:0);
-  
-  WRITE_IMAGE_3D (dst, (int4){x,y,z,0}, value);
-}
-


### PR DESCRIPTION
Figured out how to make these work on nVidia and under Intel CPU opencl.  Dropped the line kernel, can be restored if there is interest.